### PR TITLE
Feat/#3 로그인뷰 리팩토링

### DIFF
--- a/LeeSangSu-assignment/Extensions/UITextField+Extension.swift
+++ b/LeeSangSu-assignment/Extensions/UITextField+Extension.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 extension UITextField {
     
@@ -101,6 +102,17 @@ extension UITextField {
     
     fileprivate enum Constants {
         static let maxIconSize = 23.0
+    }
+    
+}
+
+extension UITextField {
+    
+    var textPublisher: AnyPublisher<String?, Never> {
+        NotificationCenter.default
+            .publisher(for: UITextField.textDidChangeNotification, object: self)
+            .map { ($0.object as? UITextField)?.text }
+            .eraseToAnyPublisher()
     }
     
 }

--- a/LeeSangSu-assignment/LoginViewModel.swift
+++ b/LeeSangSu-assignment/LoginViewModel.swift
@@ -1,0 +1,52 @@
+//
+//  LoginViewModel.swift
+//  LeeSangSu-assignment
+//
+//  Created by 이상수 on 12/2/25.
+//
+
+import Foundation
+import Combine
+
+final class LoginViewModel {
+
+    let emailSubject = CurrentValueSubject<String, Never>("")
+    let passwordSubject = CurrentValueSubject<String, Never>("")
+    let loginActionSubject = PassthroughSubject<Void, Never>()
+    
+    @Published private(set) var isLoginButtonEnabled: Bool = false
+    @Published private(set) var isLoginSuccess: Bool = false
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    init() {
+        Publishers.CombineLatest(emailSubject, passwordSubject)
+            .map { email, password in
+                return !email.isEmpty && !password.isEmpty
+            }
+            .assign(to: \.isLoginButtonEnabled, on: self)
+            .store(in: &cancellables)
+            
+        loginActionSubject
+            .sink { [weak self] _ in
+                self?.handleLogin()
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func handleLogin() {
+        let email = emailSubject.value
+        
+        guard EmailUtils.isValidFormat(email) else {
+            isLoginSuccess = false
+            return
+        }
+        isLoginSuccess = true
+    }
+
+    func resetFields() {
+        emailSubject.send("")
+        passwordSubject.send("")
+        isLoginSuccess = false
+    }
+}

--- a/LeeSangSu-assignment/ViewControllers/LoginViewController2.swift
+++ b/LeeSangSu-assignment/ViewControllers/LoginViewController2.swift
@@ -1,0 +1,120 @@
+//
+//  LoginViewController2.swift
+//  LeeSangSu-assignment
+//
+//  Created by 이상수 on 12/2/25.
+//
+
+import UIKit
+import Combine
+
+final class LoginViewController2: UIViewController {
+    
+    private let loginView = LoginView()
+    private let viewModel = LoginViewModel()
+    private var cancellables = Set<AnyCancellable>()
+
+    override func loadView() {
+        view = loginView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setAddTargets()
+        bindInput()
+        bindOutput()
+    }
+    
+    private func bindInput() {
+        loginView.emailField.textPublisher
+            .compactMap { $0 }
+            .assign(to: \.value, on: viewModel.emailSubject)
+            .store(in: &cancellables)
+        
+        loginView.passwordField.textPublisher
+            .compactMap { $0 }
+            .assign(to: \.value, on: viewModel.passwordSubject)
+            .store(in: &cancellables)
+    }
+        
+    private func bindOutput() {
+        viewModel.$isLoginButtonEnabled
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isEnabled in
+                self?.loginView.loginButton.isEnabled = isEnabled
+                self?.loginView.loginButton.backgroundColor = isEnabled ? .baeminMint500 : .baeminGray200
+            }
+            .store(in: &cancellables)
+            
+        viewModel.$isLoginSuccess
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isSuccess in
+                self?.handleLogin(isSuccess: isSuccess)
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func handleLogin(isSuccess: Bool) {
+        if isSuccess {
+            pushToWelcomeVC(email: self.viewModel.emailSubject.value)
+        } else {
+            showToast(message: "이메일 형식을 지켜주세요~")
+        }
+    }
+    
+    private func setAddTargets() {
+        setEditingActions()
+        setPwButtonAction()
+        setLoginButtonAction()
+    }
+    
+    private func setEditingActions() {
+        [loginView.emailField, loginView.passwordField].forEach {
+            $0.addTarget(self, action: #selector(textFieldEditingDidBegin(_:)), for: .editingDidBegin)
+            $0.addTarget(self, action: #selector(textFieldEditingDidEnd(_:)), for: .editingDidEnd)
+        }
+    }
+    
+    @objc private func textFieldEditingDidBegin(_ sender: UITextField) {
+        sender.layer.borderColor = UIColor.baeminBlack.cgColor
+    }
+    
+    @objc private func textFieldEditingDidEnd(_ sender: UITextField) {
+        sender.layer.borderColor = UIColor.baeminGray200.cgColor
+    }
+    
+    private func setPwButtonAction() {
+        loginView.passwordClearButton.addTarget(self, action: #selector(clearPassword), for: .touchUpInside)
+        loginView.passwordToggleButton.addTarget(self, action: #selector(togglePasswordVisibility), for: .touchUpInside)
+    }
+    
+    @objc private func clearPassword() {
+        loginView.passwordField.text = ""
+        viewModel.passwordSubject.send("")
+    }
+    
+    @objc private func togglePasswordVisibility() {
+        loginView.passwordField.isSecureTextEntry.toggle()
+    }
+    
+    private func setLoginButtonAction() {
+        loginView.loginButton.addTarget(self, action: #selector(loginButtonTapped), for: .touchUpInside)
+    }
+
+    @objc private func loginButtonTapped() {
+        viewModel.loginActionSubject.send(())
+    }
+    
+    private func pushToWelcomeVC(email: String) {
+        let viewController = WelcomeViewController(email: email)
+        viewController.delegate = self
+        self.navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
+extension LoginViewController2: WelcomeViewControllerDelegate {
+    func resetLoginFields() {
+        viewModel.resetFields()
+    }
+}

--- a/LeeSangSu-assignment/Views/LoginView.swift
+++ b/LeeSangSu-assignment/Views/LoginView.swift
@@ -1,0 +1,119 @@
+//
+//  LoginView.swift
+//  LeeSangSu-assignment
+//
+//  Created by 이상수 on 12/2/25.
+//
+
+import UIKit
+
+final class LoginView: UIView {
+        
+    let emailField = UITextField()
+    let passwordField = UITextField()
+    let loginButton = UIButton()
+    let findAccountButton = UIButton()
+    
+    let passwordToggleButton = UIButton()
+    let passwordClearButton = UIButton()
+        
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setStyle()
+        setUI()
+        setLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+        
+    private func setStyle() {
+        backgroundColor = .white
+        
+        emailField.placeholder = "이메일 아이디"
+        emailField.textColor = .label
+        emailField.borderStyle = .none
+        emailField.layer.cornerRadius = 5
+        emailField.layer.borderWidth = 1
+        emailField.layer.borderColor = UIColor.baeminGray200.cgColor
+        emailField.clearButtonMode = .whileEditing
+        emailField.addLeftPadding()
+        
+        passwordField.placeholder = "비밀번호"
+        passwordField.borderStyle = .none
+        passwordField.textColor = .label
+        passwordField.layer.cornerRadius = 5
+        passwordField.layer.borderWidth = 1
+        passwordField.layer.borderColor = UIColor.baeminGray200.cgColor
+        passwordField.isSecureTextEntry = true
+        passwordField.addLeftPadding()
+        
+        passwordClearButton.setImage(UIImage(systemName: "xmark.circle.fill"), for: .normal)
+        passwordClearButton.tintColor = .gray
+        
+        let imageName = passwordField.isSecureTextEntry ? "eye.fill" : "eye.slash.fill"
+        passwordToggleButton.setImage(UIImage(systemName: imageName), for: .normal)
+        passwordToggleButton.tintColor = .gray
+        
+        let stack = UIStackView(arrangedSubviews: [passwordClearButton, passwordToggleButton])
+        stack.axis = .horizontal
+        stack.spacing = 8
+        stack.alignment = .center
+        passwordField.rightView = stack
+        passwordField.rightViewMode = .whileEditing
+        
+        loginButton.backgroundColor = .baeminGray200
+        loginButton.setTitle("로그인", for: .normal)
+        loginButton.layer.cornerRadius = 5
+        loginButton.isEnabled = false
+        
+        findAccountButton.setTitle("계정 찾기 >", for: .normal)
+        findAccountButton.setTitleColor(.black, for: .normal)
+    }
+
+    
+    private func setUI() {
+        addSubviews(
+            emailField,
+            passwordField,
+            loginButton,
+            findAccountButton
+        )
+    }
+        
+    private func setLayout() {
+        emailField.anchor(
+            top: safeAreaLayoutGuide.topAnchor,
+            leading: leadingAnchor,
+            trailing: trailingAnchor,
+            padding: .init(top: 100, left: 20, bottom: 0, right: 20),
+            height: 40
+        )
+        
+        passwordField.anchor(
+            top: emailField.bottomAnchor,
+            leading: leadingAnchor,
+            trailing: trailingAnchor,
+            padding: .init(top: 10, left: 20, bottom: 0, right: 20),
+            height: 40
+        )
+        
+        loginButton.anchor(
+            top: passwordField.bottomAnchor,
+            leading: leadingAnchor,
+            trailing: trailingAnchor,
+            padding: .init(top: 20, left: 20, bottom: 0, right: 20),
+            height: 40
+        )
+        
+        findAccountButton.anchor(
+            top: loginButton.bottomAnchor,
+            leading: leadingAnchor,
+            trailing: trailingAnchor,
+            padding: .init(top: 23, left: 20, bottom: 0, right: 20),
+            height: 40
+        )
+    }
+    
+}


### PR DESCRIPTION
## 로그인 뷰를 MVVM + Combine 구조로 리팩토링하기

### 영상

![Simulator Screen Recording - iPhone 17 Pro - 2025-12-02 at 20 45 22](https://github.com/user-attachments/assets/972dab97-1383-4695-8f48-5c1bf9f73517)

### 구현 방식

#### 1. UITextField에 textPublisher 익스텐션 추가
```swift
extension UITextField {

    var textPublisher: AnyPublisher<String?, Never> {
        NotificationCenter.default
            .publisher(for: UITextField.textDidChangeNotification, object: self)
            .map { ($0.object as? UITextField)?.text }
            .eraseToAnyPublisher()
    }

}
``` 

idTextField.textPublisher.~ , pwTextField.textPublisher.~ 같은 방식으로 접근할 수 있도록, 텍스트 필드 자체에 익스텐션을 추가하였습니다.
텍스트 필드의 값이 바뀌면, 해당 텍스트를 방출하는 퍼블리셔입니다.


#### 2. LoginViewModel

LoginViewModel의 일부는 다음과 같습니다.
```swift
final class LoginViewModel {

    let emailSubject = CurrentValueSubject<String, Never>("")
    let passwordSubject = CurrentValueSubject<String, Never>("")

    @Published private(set) var isLoginButtonEnabled: Bool = false

    private var cancellables = Set<AnyCancellable>()

    init() {
        Publishers.CombineLatest(emailSubject, passwordSubject)
            .map { email, password in
                return !email.isEmpty && !password.isEmpty
            }
            .assign(to: \.isLoginButtonEnabled, on: self)
            .store(in: &cancellables)
}
```

emailSubject 또는 passwordSubject 둘 중에 하나가 값을 방출하면, CombineLatest에 의해 둘 다 값이 방출됩니다.
로그인 버튼을 활성화하기 위해서는 두 텍스트필드가 모두 채워져있어야 하므로, 이를 감지하기 위해 사용하였습니다.


LoginViewModel의 나머지 부분은 다음과 같습니다.
```swift
final class LoginViewModel {

    let loginActionSubject = PassthroughSubject<Void, Never>()

    @Published private(set) var isLoginSuccess: Bool = false

    private var cancellables = Set<AnyCancellable>()

    init() {
        loginActionSubject
            .sink { [weak self] _ in
                self?.handleLogin()
            }
            .store(in: &cancellables)
    }

    private func handleLogin() {
        let email = emailSubject.value

        guard EmailUtils.isValidFormat(email) else {
            isLoginSuccess = false
            return
        }
        isLoginSuccess = true
    }

    func resetFields() {
        emailSubject.send("")
        passwordSubject.send("")
        isLoginSuccess = false
    }
}
```
loginActionSubject가 값을 방출하면 isLoginSuccess 값이 바뀝니다. 이는 @Published 이므로, 뷰컨에서 $isLoginSuccess를 통해 퍼블리셔를 활용할 수 있게 합니다.

resetFields()함수는 빈 문자열을 send하여 로그인 버튼을 비활성화시키게 만듭니다.



#### 3. viewcontroller
```swift
private func bindInput() {
        loginView.emailField.textPublisher
            .compactMap { $0 }
            .assign(to: \.value, on: viewModel.emailSubject)
            .store(in: &cancellables)

        loginView.passwordField.textPublisher
            .compactMap { $0 }
            .assign(to: \.value, on: viewModel.passwordSubject)
            .store(in: &cancellables)
    }
```
이메일필드/ 텍스트필드의 값이 바뀌면, 이를 뷰모델의 subject에 할당합니다. 이들은 CombineLatest에 의해 엮여있으므로, 두 필드가 모두 채워지면 알아서 로그인 버튼이 활성화되게 만들 수 있습니다.


```swift
    private func bindOutput() {
        viewModel.$isLoginButtonEnabled
            .receive(on: DispatchQueue.main)
            .sink { [weak self] isEnabled in
                self?.loginView.loginButton.isEnabled = isEnabled
                self?.loginView.loginButton.backgroundColor = isEnabled ? .baeminMint500 : .baeminGray200
            }
            .store(in: &cancellables)

        viewModel.$isLoginSuccess
            .dropFirst()
            .receive(on: DispatchQueue.main)
            .sink { [weak self] isSuccess in
                self?.handleLogin(isSuccess: isSuccess)
            }
            .store(in: &cancellables)
    }

    private func handleLogin(isSuccess: Bool) {
        if isSuccess {
            pushToWelcomeVC(email: self.viewModel.emailSubject.value)
        } else {
            showToast(message: "이메일 형식을 지켜주세요~")
        }
    }

    @objc private func loginButtonTapped() {
        viewModel.loginActionSubject.send(())
    }
```
@Published 속성 변수는, $를 통해 퍼블리셔에 접근할 수 있습니다. 두 텍스트필드가 채워지면 isLoginButtonEnabled가 활성화되고, 로그인 버튼을 업데이트합니다. (이 부분은 LoginView에 따로 함수로 빼내는 것도 좋을 것 같네요)

로그인 버튼을 누르면 loginActionSubject에서 값이 방출되고, 이에 따라 isLoginSuccess에 대한 퍼블리셔에서 값이 방출됩니다.
성공하면 다음 뷰로 이동, 실패하면 토스트 메시지를 띄웁니다.
다만 처음에 isLoginSuccess = false (기본값)설정에도 값이 방출되었기에, 로그인 뷰에 들어가자마자 아무 것도 안 해도 토스트메시지가 뜨는 현상이 발생했습니다. 따라서, 이를 방지하기 위해 처음 방출한 값은 날려벼리는 dropFirst()함수를 사용합니다.


### 추가사항
패스워드 필드에서 내용 삭제 버튼, 가시성 토글 버튼은 뷰 모델에 포함시키지 않고 뷰컨에서 addTarget으로 연결하여 처리했습니다.
이 버튼은 패스워드 필드 내에서만 유효한 버튼이고, 로그인 로직과는 크게 관련이 없는 별개의 사항이라고 생각했기 때문입니다.
